### PR TITLE
NEW Adds link between template, user and groups for get template

### DIFF
--- a/resources/migrations/20190916185127-projects-users-table.down.sql
+++ b/resources/migrations/20190916185127-projects-users-table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE usersProjects;

--- a/resources/migrations/20190916185127-projects-users-table.up.sql
+++ b/resources/migrations/20190916185127-projects-users-table.up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE usersProjects
+(id INTEGER PRIMARY KEY,
+ userId INTEGER NOT NULL,
+ projectId INTEGER NOT NULL);

--- a/resources/sql/queries/users.sql
+++ b/resources/sql/queries/users.sql
@@ -14,3 +14,7 @@ WHERE id = :id
 -- :doc Creates an user
 INSERT INTO users (email)
 VALUES (:email)
+
+-- :name get-projects-ids-for-user* :result :*
+-- :doc Returns all project ids for an user
+SELECT projectId FROM usersProjects WHERE userId = :id

--- a/src/clj/mftickets/db/users.clj
+++ b/src/clj/mftickets/db/users.clj
@@ -16,3 +16,8 @@
 (defn get-user-by-id
   [params]
   (get-user-by-id* params))
+
+(defn get-projects-ids-for-user
+  [params]
+  (or (some->> (get-projects-ids-for-user* params) (map :projectid) set)
+      #{}))

--- a/src/clj/mftickets/domain/templates.clj
+++ b/src/clj/mftickets/domain/templates.clj
@@ -6,3 +6,10 @@
   "Get's a raw template from id."
   [id]
   (some->> id (hash-map :id) db.templates/get-raw-template))
+
+(defn get-projects-ids-for-template
+  "Get's a set of projects ids for a given template."
+  [{:keys [id]}]
+  ;; As of now, one template <-> one project.
+  (or (some-> id get-raw-template :project-id hash-set)
+      #{}))

--- a/src/clj/mftickets/domain/users.clj
+++ b/src/clj/mftickets/domain/users.clj
@@ -18,10 +18,14 @@
   (db.users/create-user! params)
   (get-user params))
 
-
 (defn get-or-create-user!
   "Gets an user from db, creating if needed."
   [params]
   (if-let [user (get-user params)]
     user
     (create-user! params)))
+
+(defn get-projects-ids-for-user
+  "Returns a set of project ids for an user."
+  [{:keys [id]}]
+  (db.users/get-projects-ids-for-user {:id id}))

--- a/src/clj/mftickets/routes/services.clj
+++ b/src/clj/mftickets/routes/services.clj
@@ -52,7 +52,11 @@
               :config {:validator-url nil}})}]]
 
    (into ["/login" {}] routes.services.login/routes)
-   (into ["/templates" {}] routes.services.templates/routes)
+   (into
+    ["/templates"
+     {:middleware [[middleware.auth/wrap-auth routes.services.helpers/token->user-or-err]]
+      :parameters {:header {:authorization string?}}}]
+    routes.services.templates/routes)
 
    ["/ping"
     {:middleware [[middleware.auth/wrap-auth routes.services.helpers/token->user-or-err]]

--- a/test/clj/mftickets/db/users_test.clj
+++ b/test/clj/mftickets/db/users_test.clj
@@ -1,0 +1,20 @@
+(ns mftickets.db.users-test
+  (:require [mftickets.db.users :as sut]
+            [mftickets.test-utils :as test-utils]
+            [clojure.test :as t :refer [is are deftest testing use-fixtures]]))
+
+(deftest test-get-project-ids-for-user
+
+  (test-utils/with-db
+    (test-utils/insert! :usersProjects {:userId 1 :projectId 1})
+    (test-utils/insert! :usersProjects {:userId 1 :projectId 2})
+    (test-utils/insert! :usersProjects {:userId 2 :projectId 3})
+
+    (testing "Two projects"
+      (is (= (sut/get-projects-ids-for-user {:id 1}) #{1 2})))
+
+    (testing "One project"
+      (is (= (sut/get-projects-ids-for-user {:id 2}) #{3})))
+
+    (testing "No project"
+      (is (= (sut/get-projects-ids-for-user {:id 3}) #{})))))

--- a/test/clj/mftickets/domain/templates_test.clj
+++ b/test/clj/mftickets/domain/templates_test.clj
@@ -17,3 +17,17 @@
               :name "Foo"
               :creation-date "2019-09-14T19:08:45"}
              (sut/get-raw-template 1))))))
+
+(deftest test-get-projects-ids-for-template
+
+  (testing "Base"
+    (test-utils/with-db
+      (test-utils/insert!
+       :templates
+       {:id 1 :projectId 1 :name "Foo" :creationDate "2019-09-14T19:08:45"})
+
+      (testing "Existing" 
+        (is (= #{1} (sut/get-projects-ids-for-template {:id 1}))))
+
+      (testing "Non existing" 
+        (is (= #{} (sut/get-projects-ids-for-template {:id 2})))))))

--- a/test/clj/mftickets/test_utils.clj
+++ b/test/clj/mftickets/test_utils.clj
@@ -1,14 +1,21 @@
 (ns mftickets.test-utils
   (:require
    [mftickets.db.core :as db.core]
+   [mftickets.domain.users :as domain.user]
    [conman.core :as conman]
    [mount.core :as mount]
    [mftickets.config :as config]
    [luminus-migrations.core :as migrations]
    [muuntaja.core :as muuntaja]
-   [clojure.java.jdbc :as jdbc]))
+   [clojure.java.jdbc :as jdbc]
+   [ring.mock.request :as mock.request]))
 
 (def test-db "jdbc:sqlite:mftickets_test.db")
+
+(defn insert!
+  "Wrapper around jdbc insert!"
+  [table params]
+  (jdbc/insert! db.core/*db* table params))
 
 (defmacro with-db
   "A function to be used to tests that demand db access."
@@ -32,12 +39,23 @@
                  #'mftickets.handler/init-app
                  #'mftickets.handler/app-routes)))
 
+(defmacro with-user-and-token
+  "Context handler providing an user and a token."
+  [[user-sym token-sym] & body]
+  {:pre [(symbol? user-sym) (symbol? token-sym)]}
+  `(do
+     (insert! :users {:id 1 :email "user@user.com"})
+     (insert! :userLoginTokens {:id 1 :userId 1 :value "foo" :createdAt "2019-01-01T12:12:12"})
+     (let [~user-sym (domain.user/get-user-by-id {:id 1})
+           ~token-sym "foo"]
+       ~@body)))
+
 (defn decode-response-body
   "Parses and returns the body of a request"
   [r]
   (muuntaja/decode-response-body r))
 
-(defn insert!
-  "Wrapper around jdbc insert!"
-  [table params]
-  (jdbc/insert! db.core/*db* table params))
+(defn auth-header
+  "Adds a token to the header of a request."
+  [request token-value]
+  (mock.request/header request "authorization" (str "Bearer " token-value)))


### PR DESCRIPTION
Adds basic logic to authenticate if a user has authorization to see a
specific template by checking the groups the user belong to.

- Creates table to host relations between users and projects.
- Adds functionalities to query which projects an user and/or template
  belong to.
- Adds auth middleware to the template views.