### PR TITLE
NEW Adds pagination for templates

### DIFF
--- a/env/dev/clj/user.clj
+++ b/env/dev/clj/user.clj
@@ -1,17 +1,16 @@
 (ns user
   "Userspace functions you can run by default in your local REPL."
-  (:require
-    [mftickets.config :refer [env]]
-    [clojure.spec.alpha :as s]
-    [expound.alpha :as expound]
-    [mount.core :as mount]
-    [mftickets.core :refer [start-app]]
-    [mftickets.db.core :as db.core]
-    [mftickets.db.prefill :as db.prefill]
-    [conman.core :as conman]
-    [luminus-migrations.core :as migrations]))
+  (:require [clojure.spec.alpha :as spec]
+            [conman.core :as conman]
+            [expound.alpha :as expound]
+            [luminus-migrations.core :as migrations]
+            [mftickets.config :refer [env]]
+            [mftickets.core :refer [start-app]]
+            [mftickets.db.core :as db.core]
+            [mftickets.db.prefill :as db.prefill]
+            [mount.core :as mount]))
 
-(alter-var-root #'s/*explain-out* (constantly expound/printer))
+(alter-var-root #'spec/*explain-out* (constantly expound/printer))
 
 (add-tap (bound-fn* clojure.pprint/pprint))
 
@@ -64,3 +63,5 @@
   "Runs all prefills from mftickets.db.prefill"
   []
   (db.prefill/run-prefills! db.core/*db*))
+
+(spec/check-asserts true)

--- a/resources/sql/queries/templates.sql
+++ b/resources/sql/queries/templates.sql
@@ -8,4 +8,16 @@ WHERE id = :id;
 -- :doc Gets the raw values for templates of a project
 SELECT id, projectId, name, creationDate
 FROM templates
+WHERE projectId = :project-id
+/*~ (when (:pagination params) */
+ORDER BY id ASC
+LIMIT :value:pagination.limit
+OFFSET :value:pagination.offset
+/*~ ) ~*/
+;
+
+-- :name count-templates-for-project* :result :1
+-- :doc Counts how many templates there are for a project.
+SELECT COUNT(*) AS response
+FROM templates
 WHERE projectId = :project-id;

--- a/src/clj/mftickets/domain/templates.clj
+++ b/src/clj/mftickets/domain/templates.clj
@@ -1,17 +1,23 @@
 (ns mftickets.domain.templates
-  (:require
-   [mftickets.db.templates :as db.templates]
-   [com.rpl.specter :as s]))
+  (:require [clojure.spec.alpha :as spec]
+            [com.rpl.specter :as s]
+            [mftickets.db.templates :as db.templates]
+            [mftickets.domain.templates.inject :as domain.templates.inject]
+            [mftickets.middleware.pagination :as middleware.pagination]))
 
+;; Fns
 (defn get-raw-template
   "Get's a raw template from id."
   [id]
   (some->> id (hash-map :id) db.templates/get-raw-template))
 
-(defn get-raw-templates-for-project
+(defn- get-raw-templates-for-project
   "Returns a list of raw templates for a project."
-  [{:keys [id]}]
-  (some->> id (hash-map :project-id) db.templates/get-raw-templates-for-project))
+  [{{:keys [id]} :project ::middleware.pagination/keys [page-number page-size]}]
+  (let [opts {:project-id id
+              ::middleware.pagination/page-number page-number
+              ::middleware.pagination/page-size page-size}]
+    (db.templates/get-raw-templates-for-project opts)))
 
 (defn get-projects-ids-for-template
   "Get's a set of projects ids for a given template."
@@ -33,7 +39,44 @@
   [template properties]
   (into {} (reduce assoc-property-to-template template properties)))
 
+(defn assoc-sections-to-template
+  "Assocs a sequence of sections to a template."
+  [{:keys [id] :as template} sections]
+  (let [sections* (s/select [(s/filterer [:template-id #(= % id)]) s/ALL] sections)]
+    (assoc template :sections sections*)))
+
+(defn raw-template->template
+  "Transforms a raw template into a template."
+  [template properties sections]
+  (-> template
+      (assoc-sections-to-template sections)
+      (assoc-properties-to-template properties)))
+
 (defn count-templates-for-project
   "Counts the number of templates for a project."
   [{:keys [id]}]
   (->> id (hash-map :project-id) db.templates/count-templates-for-project))
+
+(defn get-templates-for-project
+  "Returns a list of templates for a project."
+  [{::domain.templates.inject/keys [get-properties-for-templates get-sections-for-templates]
+    :as inject}
+   {:keys [project] ::middleware.pagination/keys [page-number page-size]}]
+
+  {:pre [(fn? get-properties-for-templates) (fn? get-sections-for-templates)]}
+
+  (let [raw-templates-opts
+        {:project project
+         ::middleware.pagination/page-number page-number
+         ::middleware.pagination/page-size page-size}
+
+        raw-templates
+        (get-raw-templates-for-project raw-templates-opts)
+
+        properties
+        (get-properties-for-templates raw-templates)
+
+        sections
+        (get-sections-for-templates raw-templates)]
+    
+    (map #(raw-template->template % properties sections) raw-templates)))

--- a/src/clj/mftickets/domain/templates/inject.clj
+++ b/src/clj/mftickets/domain/templates/inject.clj
@@ -1,0 +1,5 @@
+(ns mftickets.domain.templates.inject
+  (:require [clojure.spec.alpha :as spec]))
+
+(spec/def ::get-properties-for-templates fn?)
+(spec/def ::mk-sections-getter fn?)

--- a/src/clj/mftickets/domain/templates/properties.clj
+++ b/src/clj/mftickets/domain/templates/properties.clj
@@ -8,6 +8,11 @@
   [template]
   (db.templates.properties/get-properties-for-template template))
 
+(defn get-properties-for-templates
+  "Returns a list with all properties for a list of templates."
+  [template]
+  (db.templates.properties/get-properties-for-templates-ids (map :id template)))
+
 (defn properties-getter
   "Given a list of templates, returns a getter fn for the template properties."
   [templates]

--- a/src/clj/mftickets/domain/templates/sections.clj
+++ b/src/clj/mftickets/domain/templates/sections.clj
@@ -8,6 +8,11 @@
   [template]
   (db.templates.sections/get-sections-for-template template))
 
+(defn get-sections-for-templates
+  "Returns a list of sections for a list of templates."
+  [templates]
+  (->> templates (map :id) db.templates.sections/get-sections-for-templates-ids))
+
 (defn sections-getter
   "Given a list of templates, returns a getter fn for the template sections"
   [templates]

--- a/src/clj/mftickets/inject.clj
+++ b/src/clj/mftickets/inject.clj
@@ -1,8 +1,18 @@
 (ns mftickets.inject
-  (:require
-   [mftickets.domain.projects :as domain.projects]
-   [mftickets.domain.templates :as domain.templates]))
+  (:require 
+            [mftickets.domain.projects :as domain.projects]
+            [mftickets.domain.templates.inject :as domain.templates.inject]
+            [mftickets.domain.templates :as domain.templates]
+            [mftickets.domain.templates.properties :as domain.templates.properties]
+            [mftickets.domain.templates.sections :as domain.templates.sections]))
 
 (def inject
-  {::domain.projects/count-templates domain.templates/count-templates-for-project})
+  {::domain.projects/count-templates
+   domain.templates/count-templates-for-project
+
+   ::domain.templates.inject/get-properties-for-templates
+   domain.templates.properties/get-properties-for-templates
+
+   ::domain.templates.inject/get-sections-for-templates
+   domain.templates.sections/get-sections-for-templates})
 

--- a/src/clj/mftickets/middleware/pagination.clj
+++ b/src/clj/mftickets/middleware/pagination.clj
@@ -1,0 +1,48 @@
+(ns mftickets.middleware.pagination
+  (:require [clojure.core.match :as match]
+            [clojure.spec.alpha :as spec]))
+
+;; Specs
+(spec/def ::page-number number?)
+(spec/def ::page-size number?)
+(spec/def ::pagination-data (spec/keys :req [::page-number ::page-size]))
+(spec/def ::items seqable?)
+(spec/def ::total-items-count int?)
+(spec/def ::response (spec/and (spec/keys :opt [::items ::total-items-count])
+                               #(if (:items %) (:total-items-count %) true)))
+
+;; Impl
+(def default-page-number 1)
+(def default-page-size 50)
+
+(defn- assoc-page-number
+  "Parses the page number from the request"
+  [{{{page-number :pageNumber} :query} :parameters :as request}]
+  (assoc request ::page-number (or page-number default-page-number)))
+
+(defn- assoc-page-size
+  "Parses the page size from the request"
+  [{{{page-size :pageSize} :query} :parameters :as request}]
+  (assoc request ::page-size (or page-size default-page-size)))
+
+(defn- assoc-response-body-from-items
+  "Given a ring response with ::items, assocs it's body"
+  [{::keys [page-number page-size] :as request}
+   {::keys [items total-items-count] :as response}]
+
+  {:pre [(spec/assert ::response response) (spec/assert ::pagination-data request)]}
+
+  (cond-> response
+    items (assoc :body {:page-number page-number
+                        :page-size page-size
+                        :total-items-count total-items-count
+                        :items items})))
+
+;; API
+(defn wrap-pagination-data
+  "Middleware adding pagination data to the request."
+  [handler]
+  (fn i-wrap-pagination-data [request]
+    (let [request* (-> request assoc-page-number assoc-page-size)
+          response (handler request*)]
+      (assoc-response-body-from-items request* response))))

--- a/test/clj/mftickets/db/core_test.clj
+++ b/test/clj/mftickets/db/core_test.clj
@@ -1,0 +1,19 @@
+(ns mftickets.db.core-test
+  (:require [clojure.test :as t :refer [are deftest is testing use-fixtures]]
+            [mftickets.db.core :as sut]
+            [mftickets.middleware.pagination :as middleware.pagination]))
+
+(deftest test-parse-pagination-data
+
+  (testing "No params"
+    (is (= nil (sut/parse-pagination-data {})))
+    (is (= nil (sut/parse-pagination-data nil))))
+
+  (testing "WIth params"
+    (let [page-size 5
+          page-number 3
+          pagination-data #::middleware.pagination{:page-size page-size
+                                                   :page-number page-number}]
+      
+      (is (= {:offset (-> page-number dec (* page-size)) :limit page-size}
+             (sut/parse-pagination-data pagination-data))))))

--- a/test/clj/mftickets/db/templates_test.clj
+++ b/test/clj/mftickets/db/templates_test.clj
@@ -12,3 +12,15 @@
       (let [template (tu/gen-save! tu/template {:id 1})]
         (is (= template (sut/get-raw-template {:id 1})))
         (is (nil? (sut/get-raw-template {:id 2})))))))
+
+(deftest test-count-templates-for-project
+
+  (testing "No templates"
+    (tu/with-db
+      (is (= 0 (sut/count-templates-for-project {:project-id 1})))))
+
+  (testing "Two templates"
+    (tu/with-db
+      (tu/gen-save! tu/template {:id 1 :project-id 1})
+      (tu/gen-save! tu/template {:id 2 :project-id 1})
+      (is (= 2 (sut/count-templates-for-project {:project-id 1}))))))

--- a/test/clj/mftickets/middleware/pagination_test.clj
+++ b/test/clj/mftickets/middleware/pagination_test.clj
@@ -1,0 +1,122 @@
+(ns mftickets.middleware.pagination-test
+  (:require [mftickets.middleware.pagination :as sut]
+            [clojure.test :as t :refer [is are deftest testing use-fixtures]]))
+
+;; Helpers
+(defn- with-page-number
+  [request page-number]
+  (assoc-in request [:parameters :query :pageNumber] page-number))
+
+(defn- with-page-size
+  [request page-size]
+  (assoc-in request [:parameters :query :pageSize] page-size))
+
+;; Tests
+(deftest test-wrap-pagination-data
+
+  (testing "Assocs defaults if no args."
+    (let [request {::foo ::bar}
+          handler (sut/wrap-pagination-data identity)]
+      (is (= (assoc request
+                    ::sut/page-number sut/default-page-number
+                    ::sut/page-size sut/default-page-size)
+             (handler request)))))
+
+  (testing "Given a request with page-number and page-size..."
+    (let [page-number 2
+          page-size 30
+          request (-> {} (with-page-number page-number) (with-page-size page-size))
+          handler (sut/wrap-pagination-data identity)
+          response (handler request)]
+
+      (testing "Assocs ::page-number"
+        (is (= page-number (::sut/page-number response))))
+
+      (testing "Assocs ::page-size"
+        (is (= page-size (::sut/page-size response))))
+
+      (testing "Given a response with ::items and ::total-items-count"
+        (let [items [1 2 3]
+              total-items-count 3
+              response {::sut/items items ::sut/total-items-count total-items-count}
+              handler (sut/wrap-pagination-data (constantly response))
+              response* (handler request)]
+
+          (testing "Assocs body"
+            (is (= {:page-number page-number
+                    :page-size page-size
+                    :total-items-count total-items-count
+                    :items items}
+                   (:body response*)))))))))
+
+
+(deftest test-assoc-page-number
+
+  (let [assoc-page-number #'sut/assoc-page-number]
+
+    (testing "No parameters -> assocs default page-number"
+      (let [request {::foo ::bar}
+            response (assoc-page-number request)]
+        (is (= (assoc request ::sut/page-number sut/default-page-number)
+               response))))
+
+    (testing "With pageNumber -> assocs it"
+      (let [page-number 22
+            request (-> {} (with-page-number page-number))
+            response (assoc-page-number request)]
+        (is (= page-number (::sut/page-number response)))))
+
+    (testing "With no pageNumber but pageSize, assocs default page-number"
+      (let [page-size 2
+            request (-> {} (with-page-size page-size))
+            response (assoc-page-number request)]
+        (is (= sut/default-page-number (::sut/page-number response)))))))
+
+(deftest test-assoc-page-size
+
+  (let [assoc-page-size #'sut/assoc-page-size]
+
+    (testing "No parameters -> assocs page-size to default"
+      (let [request {::foo ::bar}
+            response (assoc-page-size request)]
+        (is (= (assoc request ::sut/page-size sut/default-page-size)
+               response))))
+
+    (testing "With pageSize -> assoc page-size to it"
+      (let [page-size 15
+            request (-> {} (with-page-size page-size))
+            response (assoc-page-size request)]
+        (is (= page-size (::sut/page-size response)))))
+
+    (testing "With no pageSize but pageNumber, assocs page-size to default."
+      (let [page-number 2
+            request (-> {} (with-page-number page-number))
+            response (assoc-page-size request)]
+        (is (= sut/default-page-size (::sut/page-size response)))))))
+
+(deftest test-assoc-response-body-from-items
+
+  (let [assoc-response-body-from-items #'sut/assoc-response-body-from-items]
+
+    (testing "Skip if items is nil"
+      (let [response {:body "Foo"}
+            request {::sut/page-number 2 ::sut/page-size 20}]
+        (are [x] (= response (assoc-response-body-from-items (merge request x) response))
+          {}
+          {::sut/items nil})))
+
+    (testing "Assocs body if items is given."
+      (let [page-number 3
+            page-size 25
+            items [:one :two]
+            total-items-count 150
+            request {::sut/page-number page-number
+                     ::sut/page-size page-size}
+            response {::sut/total-items-count total-items-count ::sut/items items}
+            response* (assoc-response-body-from-items request response)]
+        (is (= (assoc response
+                      :body {:page-number page-number
+                             :page-size page-size
+                             :total-items-count total-items-count
+                             :items items})
+               response*))))))


### PR DESCRIPTION
Adds pagination for the get templates call. Uses
`middleware.pagination` to abstract common pagination features and
implements it on `domain.templates` calls.