### PR TITLE
OPT Removes aot for factories implementation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -63,8 +63,7 @@
                   :resource-paths ["env/dev/resources"]
                   :repl-options {:init-ns user}
                   :injections [(require 'pjstadig.humane-test-output)
-                               (pjstadig.humane-test-output/activate!)]
-                  :aot [mftickets.test-utils.impl.factories]}
+                               (pjstadig.humane-test-output/activate!)]}
    :project/test {:jvm-opts ["-Dconf=test-config.edn"]
                   :resource-paths ["env/test/resources"]}
    :profiles/dev {}

--- a/test/clj/mftickets/test_utils.clj
+++ b/test/clj/mftickets/test_utils.clj
@@ -9,15 +9,7 @@
    [luminus-migrations.core :as migrations]
    [muuntaja.core :as muuntaja]
    [clojure.java.jdbc :as jdbc]
-   [ring.mock.request :as mock.request])
-  (:import
-   (mftickets.test_utils.impl.factories Template)
-   (mftickets.test_utils.impl.factories TemplateSection)
-   (mftickets.test_utils.impl.factories TemplateSectionProperty)
-   (mftickets.test_utils.impl.factories UserLoginToken)
-   (mftickets.test_utils.impl.factories UsersProjects)
-   (mftickets.test_utils.impl.factories Project)
-   (mftickets.test_utils.impl.factories User)))
+   [ring.mock.request :as mock.request]))
 
 (def test-db "jdbc:sqlite:mftickets_test.db")
 
@@ -86,10 +78,10 @@
   ([strategy] (gen-save! strategy {}))
   ([strategy opts] (impl.factories/gen-save! strategy opts insert!)))
 (defn save! [strategy obj] (impl.factories/save! strategy obj))
-(def template (impl.factories/Template.))
-(def template-section (impl.factories/TemplateSection.))
-(def template-section-property (impl.factories/TemplateSectionProperty.))
-(def user-login-token (impl.factories/UserLoginToken.))
-(def users-projects (impl.factories/UsersProjects.))
-(def project (impl.factories/Project.))
-(def user (impl.factories/User.))
+(def template (impl.factories/->Template))
+(def template-section (impl.factories/->TemplateSection))
+(def template-section-property (impl.factories/->TemplateSectionProperty))
+(def user-login-token (impl.factories/->UserLoginToken))
+(def users-projects (impl.factories/->UsersProjects))
+(def project (impl.factories/->Project))
+(def user (impl.factories/->User))

--- a/test/clj/mftickets/test_utils/impl/factories.clj
+++ b/test/clj/mftickets/test_utils/impl/factories.clj
@@ -33,7 +33,9 @@
     (save! strategy obj insert!)))
 
 ;; Implementations
-(deftype UserLoginToken []
+(deftype UserLoginToken [])
+
+(extend-type UserLoginToken
   Factory
   (gen [_ opts]
     (merge
@@ -54,7 +56,8 @@
       :created-at :createdAt}))
   (standardize-raw-obj [_ x] x))
 
-(deftype UsersProjects []
+(deftype UsersProjects [])
+(extend-type UsersProjects
   Factory
   (gen [_ opts]
     (merge {:user-id 1 :project-id 1} opts))
@@ -65,7 +68,8 @@
     (clojure.set/rename-keys opts {:user-id :userId :project-id :projectId}))
   (standardize-raw-obj [_ x] x))
 
-(deftype Project []
+(deftype Project [])
+(extend-type Project
   Factory
   (gen [_ opts]
     (merge {:id 1 :name "My Project" :description "My project description"} opts))
@@ -75,7 +79,8 @@
   (serialize-to-db [_ opts] opts)
   (standardize-raw-obj [_ x] x))
 
-(deftype User []
+(deftype User [])
+(extend-type User
   Factory
   (gen [_ opts] (merge {:id 1 :email "foo@bar.com"} opts))
 
@@ -84,7 +89,9 @@
   (serialize-to-db [_ opts] opts)
   (standardize-raw-obj [_ x] x))
 
-(deftype Template []
+
+(deftype Template [])
+(extend-type Template
   Factory
   (gen [_ opts]
     (merge
@@ -97,7 +104,8 @@
     {:id id :projectId project-id :name name :creationDate creation-date})
   (standardize-raw-obj [_ x] x))
 
-(deftype TemplateSection []
+(deftype TemplateSection [])
+(extend-type TemplateSection
   Factory
   (gen [_ opts] (merge {:id 1 :template-id 9 :name "Foo" :order 0} opts))
 
@@ -107,7 +115,8 @@
     (clojure.set/rename-keys opts {:template-id :templateId :order :orderIndex}))
   (standardize-raw-obj [_ x] x))
 
-(deftype TemplateSectionProperty []
+(deftype TemplateSectionProperty [])
+(extend-type TemplateSectionProperty
   Factory
   (gen [_ opts]
     (merge


### PR DESCRIPTION
For some reason, when using `extend-type` rather than `deftype`, we
don't need to AOT compile the factories.